### PR TITLE
fix: correct typo + add target blank

### DIFF
--- a/index.html
+++ b/index.html
@@ -652,7 +652,7 @@
 						</textarea>
 					</section>
 					<section>
-						<div style="display:flex;justify-content:center; align-items:center;"><img src="./img/github.svg" /> <a href="https://github.com/jesseduffield/lazydocker">LazyDocker on Github</a></div>
+						<div style="display:flex;justify-content:center; align-items:center;"><img src="./img/github.svg" /> <a href="https://github.com/jesseduffield/lazydocker" target="_blank">LazyDocker on Github</a></div>
 					</section>
 				</section>
 
@@ -786,7 +786,7 @@
 							#### docker-compose build [OPTIONS]
 
 							* Permet de construire les images docker en local des différents services d'un fichier docker compose
-							* Cette commande est utile si les images (Dockerfile) utilisentsont construites directement par le fichier docker compose
+							* Cette commande est utile si les images (Dockerfile) utilisées sont construites directement par le fichier docker compose
 							
 							```shell
 							docker-compose build
@@ -798,7 +798,7 @@
 							#### docker-compose pull [OPTIONS]
 
 							* Permet de récupérer les images docker d'un registry externe pour les télécharger en local
-							* Si j'utilise pour un a plusieurs services des images du registry, cette commande permet de les récupérer en local pour pouvoir les utiliser
+							* Si j'utilise, pour un à plusieurs services, des images du registry : cette commande permet de les récupérer en local pour pouvoir les utiliser
 
 							```shell
 							docker-compose pull


### PR DESCRIPTION
Corrections of some typos
Add target blank to open link in new tab